### PR TITLE
feat: Implement dynamic summary length based on URL length (#11)

### DIFF
--- a/src/jpgovsummary/agents/summary_integrator.py
+++ b/src/jpgovsummary/agents/summary_integrator.py
@@ -14,6 +14,10 @@ def summary_integrator(state: State) -> State:
     overview = state.get("overview", "")
     url = state.get("url", "")
     
+    # URLの長さに基づいて動的に文字数制限を計算
+    url_length = len(url)
+    max_chars = max(50, 300 - url_length - 1)  # 最低50文字は確保
+    
     if not target_report_summaries:
         logger.warning("No report summaries found")
         final_summary = overview if overview else "要約を生成できませんでした。"
@@ -34,16 +38,16 @@ def summary_integrator(state: State) -> State:
     try:
         # Step 1: 資料の要約をまとめる
         combined_summary_prompt = PromptTemplate(
-            input_variables=["summaries"],
+            input_variables=["summaries", "max_chars"],
             template="""
-            以下の複数の資料の要約をまとめて、200文字程度の簡潔な要約を作成してください。
+            以下の複数の資料の要約をまとめて、{max_chars}文字以下の簡潔な要約を作成してください。
             重要な情報を漏らさないようにしながら、重複を避け、論理的な流れを保ってください。
 
             # 資料の要約:
             {summaries}
             
             # 出力形式
-            - 200文字程度の要約文
+            - {max_chars}文字以下の要約文
             - 箇条書きではなく、文章形式で
             - 専門用語は適切に使用
             - 内容の重複を避ける
@@ -52,15 +56,16 @@ def summary_integrator(state: State) -> State:
         
         # 資料の要約を統合
         combined_result = llm.invoke(combined_summary_prompt.format(
-            summaries=summaries_text
+            summaries=summaries_text,
+            max_chars=max_chars
         ))
         combined_summary = combined_result.content.strip()
         
         # Step 2: 統合した要約とoverviewを合わせて最終要約を作成
         final_summary_prompt = PromptTemplate(
-            input_variables=["combined_summary", "overview"],
+            input_variables=["combined_summary", "overview", "max_chars"],
             template="""
-            以下の要約内容をもとに、200文字程度で全体の要約を作成してください。
+            以下の要約内容をもとに、{max_chars}文字以下で全体の要約を作成してください。
 
             【重要な指示】
             - overviewに含まれている会議名や資料名（例：「第1回○○会議」など）は、省略せず必ず要約文中に残してください。
@@ -74,7 +79,7 @@ def summary_integrator(state: State) -> State:
             {combined_summary}
 
             # 出力形式
-            - 200文字程度の要約文
+            - {max_chars}文字以下の要約文
             - 箇条書きではなく、文章形式でまとめる
             - 会議名や資料名（回数含む）が必ず含まれていること
             - 専門用語は適切に使用する
@@ -86,7 +91,8 @@ def summary_integrator(state: State) -> State:
         # 最終要約を生成
         final_result = llm.invoke(final_summary_prompt.format(
             combined_summary=combined_summary,
-            overview=overview
+            overview=overview,
+            max_chars=max_chars
         ))
         final_summary = final_result.content.strip()
         


### PR DESCRIPTION
## 概要
Issue #11 の実装: summary_integratorの要約文字数制限をURLの長さに基づいて動的に調整

## 変更内容
- 200文字固定だった要約文字数制限を `300 - len(state["url"]) - 1` 文字に変更
- 最低50文字の保証機能を追加
- プロンプトテンプレートで動的文字数制限を使用

## 実装詳細
- URLの長さを計算: `url_length = len(url)`
- 動的文字数制限: `max_chars = max(50, 300 - url_length - 1)`
- 複数資料要約統合と最終要約生成の両方で適用

## テスト
- 動作確認済み

## 関連Issue
Closes #11