### PR TITLE
fix: Remove verbose output from load_summarize_chain (#19)

### DIFF
--- a/src/jpgovsummary/agents/document_summarizer.py
+++ b/src/jpgovsummary/agents/document_summarizer.py
@@ -135,7 +135,7 @@ def document_summarizer(state: State) -> State:
                 chain_type="map_reduce",
                 map_prompt=map_prompt,
                 combine_prompt=combine_prompt,
-                verbose=True,
+                verbose=False,
             )
 
             summary_result = chain.invoke(docs)


### PR DESCRIPTION
## 概要
Issue #19 で報告された `load_summarize_chain()` の余分な出力を抑制する修正です。

## 変更内容
- `src/jpgovsummary/agents/document_summarizer.py` の134行目付近で `verbose=True` を `verbose=False` に変更
- これにより、要約処理時の詳細なログ出力が抑制されます

## 修正箇所
```python
# 変更前
chain = load_summarize_chain(
    llm,
    chain_type="map_reduce",
    map_prompt=map_prompt,
    combine_prompt=combine_prompt,
    verbose=True,  # ← 余分な出力の原因
)

# 変更後  
chain = load_summarize_chain(
    llm,
    chain_type="map_reduce",
    map_prompt=map_prompt,
    combine_prompt=combine_prompt,
    verbose=False,  # ← 出力を抑制
)
```

## テスト
- コードの動作に影響しない設定変更のため、既存の機能は維持されます
- 出力がよりクリーンになり、重要なログが見やすくなります

Closes #19