### PR TITLE
feat: Support local file processing for PDF and HTML files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pycryptodome = "^3.23.0"
 ruff = "^0.11.12"
 
 [tool.poetry.scripts]
-jpgovsummary = "jpgovsummary.main:main"
+jpgovsummary = "jpgovsummary.jpgovwatcher:main"
 
 [tool.ruff]
 # Python version compatibility

--- a/src/jpgovsummary/__main__.py
+++ b/src/jpgovsummary/__main__.py
@@ -1,0 +1,9 @@
+"""
+Entry point for jpgovsummary package when run as a module.
+"""
+
+import sys
+from .jpgovwatcher import main
+
+if __name__ == "__main__":
+    sys.exit(main()) 

--- a/src/jpgovsummary/tools/html_loader.py
+++ b/src/jpgovsummary/tools/html_loader.py
@@ -3,25 +3,36 @@ from langchain_core.tools import tool
 from markitdown import MarkItDown
 
 from .. import logger
+from ..utils import is_local_file, get_local_file_path, validate_local_file
 
 
 def load_html_as_markdown(url: str) -> str:
     """
-    Load HTML page into markdown string.
+    Load HTML page into markdown string from URL or local file.
 
     Args:
-        url (str): URL of the page with ending .html
+        url (str): URL of the page with ending .html or local file path
 
     Returns:
         str: markdown of the page
     """
-    headers = {
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
-    }
-    response = requests.get(url, headers=headers, timeout=30, verify=True)
-    response.raise_for_status()
-    markdown = MarkItDown().convert(response)
-    return markdown.text_content
+    if is_local_file(url):
+        # Handle local file
+        file_path = get_local_file_path(url)
+        validate_local_file(file_path)
+        
+        # Read local HTML file and convert to markdown using MarkItDown
+        markdown = MarkItDown().convert(file_path)
+        return markdown.text_content
+    else:
+        # Handle remote URL (existing logic)
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+        }
+        response = requests.get(url, headers=headers, timeout=30, verify=True)
+        response.raise_for_status()
+        markdown = MarkItDown().convert(response)
+        return markdown.text_content
 
 
 @tool

--- a/src/jpgovsummary/utils.py
+++ b/src/jpgovsummary/utils.py
@@ -1,0 +1,66 @@
+"""
+Utility functions for jpgovsummary
+"""
+
+import os
+from urllib.parse import urlparse
+
+
+def is_local_file(path: str) -> bool:
+    """
+    Check if the given path is a local file path.
+    
+    Args:
+        path (str): Path to check
+        
+    Returns:
+        bool: True if it's a local file path, False otherwise
+    """
+    # Check for file:// protocol
+    if path.startswith("file://"):
+        return True
+    
+    # Check for absolute path (starts with /)
+    if path.startswith("/"):
+        return True
+    
+    # Check for relative path (doesn't start with http:// or https://)
+    if not path.startswith(("http://", "https://")):
+        return True
+    
+    return False
+
+
+def get_local_file_path(path: str) -> str:
+    """
+    Convert a local file path (including file:// URLs) to a regular file path.
+    
+    Args:
+        path (str): Local file path or file:// URL
+        
+    Returns:
+        str: Regular file path
+    """
+    if path.startswith("file://"):
+        parsed = urlparse(path)
+        return parsed.path
+    else:
+        return path
+
+
+def validate_local_file(file_path: str) -> None:
+    """
+    Validate that a local file exists and is readable.
+    
+    Args:
+        file_path (str): Path to the file
+        
+    Raises:
+        FileNotFoundError: If file doesn't exist
+        ValueError: If path is not a file
+    """
+    if not os.path.exists(file_path):
+        raise FileNotFoundError(f"File not found: {file_path}")
+    
+    if not os.path.isfile(file_path):
+        raise ValueError(f"Path is not a file: {file_path}") 

--- a/tests/fixtures/test_sample.html
+++ b/tests/fixtures/test_sample.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>第3回 教育分野の認証基盤の在り方に関する検討会</title>
+</head>
+<body>
+    <header>
+        <nav>
+            <ul>
+                <li><a href="/">ホーム</a></li>
+                <li><a href="/about">概要</a></li>
+                <li><a href="/contact">お問い合わせ</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <main>
+        <h1>第3回 教育分野の認証基盤の在り方に関する検討会</h1>
+        
+        <section>
+            <h2>開催概要</h2>
+            <p>日時：令和6年3月15日（金）10:00～12:00</p>
+            <p>場所：文部科学省 3F1特別会議室</p>
+            <p>議題：組織間・外部連携における認証基盤の取りまとめ案について</p>
+        </section>
+
+        <section>
+            <h2>議事内容</h2>
+            <p>本日の検討会では、組織間・外部連携における認証基盤の取りまとめ案について議論を行いました。</p>
+            
+            <h3>主な議論点</h3>
+            <ul>
+                <li>ユースケースの整理と実装パターンの検討</li>
+                <li>個人情報保護に関する留意事項の確認</li>
+                <li>技術的な実装方法の詳細検討</li>
+                <li>スケジュールの明確化</li>
+            </ul>
+
+            <h3>決定事項</h3>
+            <p>複数自治体での実証実験を実施することが決定されました。また、実装パターンについては、セキュリティ要件を満たす形で進めることが確認されました。</p>
+        </section>
+
+        <section>
+            <h2>配布資料</h2>
+            <ul>
+                <li><a href="./documents/agenda.pdf">議事次第（PDF：1.2MB）</a></li>
+                <li><a href="./documents/summary.pdf">取りまとめ案（PDF：3.5MB）</a></li>
+                <li><a href="./documents/reference.pdf">参考資料（PDF：2.1MB）</a></li>
+            </ul>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2024 文部科学省. All rights reserved.</p>
+        <p><a href="/privacy">プライバシーポリシー</a> | <a href="/sitemap">サイトマップ</a></p>
+    </footer>
+</body>
+</html> 


### PR DESCRIPTION
## 概要
イシュー #26 の対応として、ローカルファイル（PDF、HTML）の処理機能を実装しました。

## 実装内容

### 新機能
- **ローカルファイルパス判定**: 相対パス、絶対パス、`file://`プロトコルに対応
- **ファイル拡張子判定**: `.pdf`、`.html`、`.htm`、`.txt`からページタイプを判定
- **ローカルHTMLファイル読み込み**: MarkItDownを使用してローカルHTMLをマークダウンに変換
- **ローカルPDFファイル読み込み**: PyPDF2を使用してローカルPDFからテキストを抽出

### 技術的変更
- **共通ユーティリティ**: `src/jpgovsummary/utils.py` を新規作成
  - `is_local_file()`: ローカルファイルパス判定
  - `get_local_file_path()`: file://プロトコル対応
  - `validate_local_file()`: ファイル存在確認
- **ファイル構成変更**:
  - `main.py` → `jpgovwatcher.py` にリネーム
  - `__main__.py` を新規作成（モジュール実行対応）
  - テストファイルを `tests/fixtures/` に整理

### エラーハンドリング
- ファイルが存在しない場合の適切なエラーメッセージ
- ディレクトリが指定された場合の処理
- 読み込み権限がない場合の処理

## 動作確認
- ✅ ローカルHTMLファイル: `tests/fixtures/test_sample.html`
- ✅ ローカルPDFファイル: 実際のPDFファイルで動作確認済み
- ✅ 既存のURL処理: 従来の機能に影響なし

## 使用例
```bash
# ローカルHTMLファイル
jpgovsummary ./document.html

# ローカルPDFファイル  
jpgovsummary ./report.pdf

# file://プロトコル
jpgovsummary file:///path/to/document.pdf

# 従来のURL（変更なし）
jpgovsummary https://example.gov.jp/meeting.html
```

## 期待される効果
- オフライン環境での利用が可能
- 開発・テスト時の利便性向上
- ローカルに保存されたファイルの直接処理

Closes #26