### PR TITLE
feat: Add Bluesky posting functionality after human_reviewer (#32)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1015,6 +1015,22 @@ tenacity = ">=8.1.0,<8.4.0 || >8.4.0,<10.0.0"
 typing-extensions = ">=4.7"
 
 [[package]]
+name = "langchain-mcp-adapters"
+version = "0.1.7"
+description = "Make Anthropic Model Context Protocol (MCP) tools compatible with LangChain and LangGraph agents."
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "langchain_mcp_adapters-0.1.7-py3-none-any.whl", hash = "sha256:6b3ded5f51b311e67cefa87b500f776c454caf2269d2eae4b2338ecec19a9258"},
+    {file = "langchain_mcp_adapters-0.1.7.tar.gz", hash = "sha256:b5d0ab520211d8c12cfc4df83fd6335f8197a3557ee7ca4f14e3380846610535"},
+]
+
+[package.dependencies]
+langchain-core = ">=0.3.36,<0.4"
+mcp = ">=1.9.2"
+
+[[package]]
 name = "langchain-openai"
 version = "0.3.6"
 description = "An integration package connecting OpenAI and LangChain"
@@ -1212,6 +1228,34 @@ packaging = ">=17.0"
 dev = ["marshmallow[tests]", "pre-commit (>=3.5,<5.0)", "tox"]
 docs = ["autodocsumm (==0.2.14)", "furo (==2024.8.6)", "sphinx (==8.1.3)", "sphinx-copybutton (==0.5.2)", "sphinx-issues (==5.0.0)", "sphinxext-opengraph (==0.9.1)"]
 tests = ["pytest", "simplejson"]
+
+[[package]]
+name = "mcp"
+version = "1.9.3"
+description = "Model Context Protocol SDK"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "mcp-1.9.3-py3-none-any.whl", hash = "sha256:69b0136d1ac9927402ed4cf221d4b8ff875e7132b0b06edd446448766f34f9b9"},
+    {file = "mcp-1.9.3.tar.gz", hash = "sha256:587ba38448e81885e5d1b84055cfcc0ca56d35cd0c58f50941cab01109405388"},
+]
+
+[package.dependencies]
+anyio = ">=4.5"
+httpx = ">=0.27"
+httpx-sse = ">=0.4"
+pydantic = ">=2.7.2,<3.0.0"
+pydantic-settings = ">=2.5.2"
+python-multipart = ">=0.0.9"
+sse-starlette = ">=1.6.1"
+starlette = ">=0.27"
+uvicorn = {version = ">=0.23.1", markers = "sys_platform != \"emscripten\""}
+
+[package.extras]
+cli = ["python-dotenv (>=1.0.0)", "typer (>=0.12.4)"]
+rich = ["rich (>=13.9.4)"]
+ws = ["websockets (>=15.0.1)"]
 
 [[package]]
 name = "mpmath"
@@ -2100,6 +2144,18 @@ files = [
 cli = ["click (>=5.0)"]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.20"
+description = "A streaming multipart parser for Python"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "python_multipart-0.0.20-py3-none-any.whl", hash = "sha256:8a62d3a8335e06589fe01f2a3e178cdcc632f3fbe0d492ad9ee0ec35aab1f104"},
+    {file = "python_multipart-0.0.20.tar.gz", hash = "sha256:8dd0cab45b8e23064ae09147625994d090fa46f5b0d1e13af944c331a7fa9d13"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -2464,6 +2520,45 @@ pymysql = ["pymysql"]
 sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
+name = "sse-starlette"
+version = "2.3.6"
+description = "SSE plugin for Starlette"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sse_starlette-2.3.6-py3-none-any.whl", hash = "sha256:d49a8285b182f6e2228e2609c350398b2ca2c36216c2675d875f81e93548f760"},
+    {file = "sse_starlette-2.3.6.tar.gz", hash = "sha256:0382336f7d4ec30160cf9ca0518962905e1b69b72d6c1c995131e0a703b436e3"},
+]
+
+[package.dependencies]
+anyio = ">=4.7.0"
+
+[package.extras]
+daphne = ["daphne (>=4.2.0)"]
+examples = ["aiosqlite (>=0.21.0)", "fastapi (>=0.115.12)", "sqlalchemy[asyncio,examples] (>=2.0.41)", "starlette (>=0.41.3)", "uvicorn (>=0.34.0)"]
+granian = ["granian (>=2.3.1)"]
+uvicorn = ["uvicorn (>=0.34.0)"]
+
+[[package]]
+name = "starlette"
+version = "0.47.0"
+description = "The little ASGI library that shines."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "starlette-0.47.0-py3-none-any.whl", hash = "sha256:9d052d4933683af40ffd47c7465433570b4949dc937e20ad1d73b34e72f10c37"},
+    {file = "starlette-0.47.0.tar.gz", hash = "sha256:1f64887e94a447fed5f23309fb6890ef23349b7e478faa7b24a851cd4eb844af"},
+]
+
+[package.dependencies]
+anyio = ">=3.6.2,<5"
+
+[package.extras]
+full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+
+[[package]]
 name = "sympy"
 version = "1.14.0"
 description = "Computer algebra system (CAS) in Python"
@@ -2612,6 +2707,26 @@ brotli = ["brotli (>=1.0.9) ; platform_python_implementation == \"CPython\"", "b
 h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "uvicorn"
+version = "0.34.3"
+description = "The lightning-fast ASGI server."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+markers = "sys_platform != \"emscripten\""
+files = [
+    {file = "uvicorn-0.34.3-py3-none-any.whl", hash = "sha256:16246631db62bdfbf069b0645177d6e8a77ba950cfedbfd093acef9444e4d885"},
+    {file = "uvicorn-0.34.3.tar.gz", hash = "sha256:35919a9a979d7a59334b6b10e05d77c1d0d574c50e0fc98b8b1a0f165708b55a"},
+]
+
+[package.dependencies]
+click = ">=7.0"
+h11 = ">=0.8"
+
+[package.extras]
+standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
 [[package]]
 name = "websockets"
@@ -2905,4 +3020,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.14"
-content-hash = "b6e2c297359d5e87d0315d1b8f0662186b346e61357207ce26bafe74e7bb32c5"
+content-hash = "c298f02fb225dba15542193e467442b284f3b0dd9a3880e8f94f52814a807ec3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ markitdown = "^0.1.1"
 pygraphviz = "^1.14"
 pypdf2 = "^3.0.1"
 pycryptodome = "^3.23.0"
+langchain-mcp-adapters = "^0.1.7"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.11.12"

--- a/src/jpgovsummary/agents/__init__.py
+++ b/src/jpgovsummary/agents/__init__.py
@@ -5,6 +5,7 @@ from .overview_generator import overview_generator
 from .report_enumerator import report_enumerator
 from .report_selector import report_selector
 from .summary_integrator import summary_integrator
+from .bluesky_poster import bluesky_poster
 
 __all__ = [
     "document_summarizer",
@@ -14,4 +15,5 @@ __all__ = [
     "report_enumerator",
     "report_selector",
     "summary_integrator",
+    "bluesky_poster",
 ]

--- a/src/jpgovsummary/agents/bluesky_poster.py
+++ b/src/jpgovsummary/agents/bluesky_poster.py
@@ -1,0 +1,223 @@
+import sys
+import asyncio
+import os
+from typing import Dict, Any
+from langchain_core.messages import HumanMessage, AIMessage
+from langchain_core.prompts import PromptTemplate
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+from .. import Model, State, logger
+
+
+def bluesky_poster(state: State) -> State:
+    """
+    Human reviewerの後にBlueskyへの投稿を確認・実行するエージェント
+    """
+    logger.info("bluesky_poster")
+    
+    # 最終要約とURLを取得
+    final_summary = state.get("final_review_summary") or state.get("final_summary", "")
+    url = state.get("url", "")
+    
+    if not final_summary:
+        logger.warning("No final summary available for Bluesky posting")
+        state["bluesky_post_completed"] = True
+        return state
+    
+    try:
+        # 投稿内容をフォーマット
+        post_content = _format_bluesky_content(final_summary, url)
+        
+        # ユーザーに投稿意思を確認
+        if _ask_user_for_bluesky_posting(final_summary, url, post_content):
+            print("\n📤 Posting to Bluesky...")
+            
+            # MCPClientを使ってBluesky投稿を実行
+            post_result = asyncio.run(_post_to_bluesky_via_mcp(post_content))
+            
+            if post_result["success"]:
+                print("✅ Successfully posted to Bluesky!")
+                state["bluesky_post_completed"] = True
+                state["bluesky_post_content"] = post_content
+                state["bluesky_post_requested"] = True
+                # URIが取得できる場合は保存
+                if post_result.get("result"):
+                    state["bluesky_post_uri"] = str(post_result["result"])
+            else:
+                print(f"❌ Failed to post to Bluesky: {post_result['error']}")
+                state["bluesky_post_completed"] = True
+                state["bluesky_post_requested"] = True
+        else:
+            print("❌ Bluesky posting cancelled by user.")
+            state["bluesky_post_completed"] = True
+            state["bluesky_post_requested"] = False
+            
+    except Exception as e:
+        logger.error(f"Error in bluesky_poster: {str(e)}")
+        print(f"❌ Error during Bluesky posting: {str(e)}")
+        state["bluesky_post_completed"] = True
+        
+    return state
+
+
+async def _post_to_bluesky_via_mcp(content: str) -> dict:
+    """
+    MultiServerMCPClientを使用してBlueskyに投稿
+    """
+    try:
+        logger.info("Initializing MCP client for Bluesky posting")
+        
+        # 環境変数からSSKY_USERを取得
+        ssky_user = os.getenv("SSKY_USER")
+        if not ssky_user:
+            error_msg = "SSKY_USER environment variable not set. Format: 'USER:PASSWORD'"
+            logger.error(error_msg)
+            print(f"❌ {error_msg}")
+            return {
+                "success": False,
+                "content": content,
+                "result": None,
+                "error": error_msg
+            }
+        
+        # MCPクライアントを初期化
+        client = MultiServerMCPClient({
+            "ssky": {
+                "command": "docker",
+                "args": [
+                    "run",
+                    "-i",
+                    "--rm",
+                    "-e",
+                    f"SSKY_USER={ssky_user}",
+                    "ghcr.io/simpleskyclient/ssky-mcp"
+                ],
+                "transport": "stdio",
+            }
+        })
+        
+        logger.info("Getting MCP tools")
+        # MCPツールを取得
+        try:
+            tools = await client.get_tools()
+            logger.info(f"Retrieved {len(tools)} MCP tools")
+        except Exception as e:
+            logger.error(f"Failed to get MCP tools: {str(e)}")
+            return {
+                "success": False,
+                "content": content,
+                "result": None,
+                "error": f"Failed to get MCP tools: {str(e)}"
+            }
+        
+        # ssky_postツールを直接呼び出し
+        logger.info("Finding ssky_post tool")
+        ssky_post_tool = None
+        for tool in tools:
+            if tool.name == "ssky_post":
+                ssky_post_tool = tool
+                break
+        
+        if not ssky_post_tool:
+            error_msg = "ssky_post tool not found in available tools"
+            logger.error(error_msg)
+            return {
+                "success": False,
+                "content": content,
+                "result": None,
+                "error": error_msg
+            }
+        
+        # ツールを直接実行
+        logger.info(f"Calling ssky_post tool with content: {content[:100]}...")
+        try:
+            result = await ssky_post_tool.ainvoke({
+                "message": content,
+                "dry_run": False,
+                "output_format": "text"
+            })
+            logger.info(f"ssky_post result: {result}")
+            
+            # 結果を文字列として取得
+            result_str = str(result) if result else ""
+            
+            # 成功判定（エラーメッセージがない場合は成功とみなす）
+            if "error" not in result_str.lower() and "failed" not in result_str.lower():
+                return {
+                    "success": True,
+                    "content": content,
+                    "result": result_str,
+                    "error": None
+                }
+            else:
+                return {
+                    "success": False,
+                    "content": content,
+                    "result": None,
+                    "error": result_str
+                }
+                
+        except Exception as e:
+            logger.error(f"Failed to call ssky_post tool: {str(e)}")
+            return {
+                "success": False,
+                "content": content,
+                "result": None,
+                "error": f"Failed to call ssky_post tool: {str(e)}"
+            }
+        
+    except Exception as e:
+        logger.error(f"Bluesky posting via MCP failed: {str(e)}", exc_info=True)
+        return {
+            "success": False,
+            "content": content,
+            "result": None,
+            "error": str(e)
+        }
+
+
+def _format_bluesky_content(summary: str, url: str) -> str:
+    """
+    Bluesky投稿用のコンテンツをフォーマット
+    ローカルファイルのURLの場合は付加しない
+    """
+    # URLがWebのURLかどうかを判定
+    if url and (url.startswith('http://') or url.startswith('https://')):
+        return f"{summary}\n{url}"
+    else:
+        # ローカルファイルパスの場合はURLを付加しない
+        return summary
+
+
+def _ask_user_for_bluesky_posting(summary: str, url: str, post_content: str) -> bool:
+    """
+    ユーザーにBluesky投稿の意思を確認（シンプル版）
+    """
+    # シンプルなY/n確認
+    while True:
+        try:
+            response = _safe_input("Blueskyに投稿しますか？ (Y/n): ").strip()
+            
+            # デフォルトはYes（Enterのみでも投稿）
+            if response == "" or response.lower() in ['y', 'yes']:
+                return True
+            elif response.lower() in ['n', 'no']:
+                return False
+            else:
+                print("❌ Y/y/yes または N/n/no で回答してください。")
+                
+        except (KeyboardInterrupt, EOFError):
+            return False
+
+
+def _safe_input(prompt: str, default: str = "") -> str:
+    """Safely get user input with Unicode error handling"""
+    try:
+        return input(prompt).strip()
+    except UnicodeDecodeError as e:
+        print(f"❌ 文字エンコーディングエラーが発生しました: {e}")
+        print("💡 入力に使用できない文字が含まれています。")
+        return default
+    except (EOFError, KeyboardInterrupt):
+        # Re-raise these as they should be handled by the main loop
+        raise 

--- a/src/jpgovsummary/agents/human_reviewer.py
+++ b/src/jpgovsummary/agents/human_reviewer.py
@@ -36,11 +36,7 @@ def human_reviewer(state: State) -> State:
     print("\n" + "="*80)
     print("🔍 HUMAN REVIEW SESSION - FINAL SUMMARY QUALITY CHECK")
     print("="*80)
-    print(f"\n📄 Current Summary ({len(final_summary)} characters):")
-    print("-" * 50)
-    print(final_summary)
-    print("-" * 50)
-    print(f"🔗 URL: {url}")
+    _display_current_summary(final_summary, url=url)
     
     if review_session["iteration"] > 0:
         print(f"\n📊 Review Iteration: {review_session['iteration']}")
@@ -104,6 +100,7 @@ def human_reviewer(state: State) -> State:
                                 "result": improved_summary
                             })
                             print("✅ Improvement applied!")
+                            _display_current_summary(final_summary, url=url)
                         elif result["action"] == "improve" and result["feedback"]:
                             # Apply additional improvement
                             further_improved_summary = _generate_improved_summary(
@@ -117,6 +114,7 @@ def human_reviewer(state: State) -> State:
                             })
                             print(f"\nAI> Further Improved Summary:\n{'-'*50}\n{further_improved_summary}\n{'-'*50}")
                             print("✅ Additional improvement applied!")
+                            _display_current_summary(final_summary, url=url)
                         else:
                             print("❌ Improvement rejected, keeping current summary.")
                     else:
@@ -152,6 +150,7 @@ def human_reviewer(state: State) -> State:
                                 "result": regenerated_summary
                             })
                             print("✅ Regenerated summary applied!")
+                            _display_current_summary(final_summary, url=url)
                         elif result["action"] == "improve" and result["feedback"]:
                             # Apply additional improvement to regenerated summary
                             further_improved_summary = _generate_improved_summary(
@@ -165,6 +164,7 @@ def human_reviewer(state: State) -> State:
                             })
                             print(f"\nAI> Further Improved Summary:\n{'-'*50}\n{further_improved_summary}\n{'-'*50}")
                             print("✅ Additional improvement applied!")
+                            _display_current_summary(final_summary, url=url)
                         else:
                             print("❌ Regeneration rejected, keeping current summary.")
                     else:
@@ -504,6 +504,15 @@ def _extract_regeneration_feedback(llm, user_input: str) -> str:
     except Exception as e:
         logger.error(f"Error in feedback extraction: {str(e)}")
         return ""
+
+
+def _display_current_summary(final_summary: str, url: str) -> None:
+    """現在のサマリーを表示する"""
+    print(f"\n📄 Current Summary ({len(final_summary)} characters):")
+    print("-" * 50)
+    print(final_summary)
+    print("-" * 50)
+    print(f"🔗 URL: {url}")
 
 
 def _safe_input(prompt: str, default: str = "") -> str:

--- a/src/jpgovsummary/state.py
+++ b/src/jpgovsummary/state.py
@@ -115,3 +115,24 @@ class State(TypedDict):
         description="Whether to skip the human review step for automated workflows",
         default=False,
     )
+    # Bluesky posting fields
+    skip_bluesky_posting: bool | None = Field(
+        description="Whether to skip the Bluesky posting step",
+        default=False,
+    )
+    bluesky_post_requested: bool | None = Field(
+        description="Whether user requested Bluesky posting",
+        default=None,
+    )
+    bluesky_post_completed: bool | None = Field(
+        description="Whether Bluesky posting was completed",
+        default=False,
+    )
+    bluesky_post_content: str | None = Field(
+        description="Content posted to Bluesky",
+        default=None,
+    )
+    bluesky_post_uri: str | None = Field(
+        description="URI of the posted Bluesky content",
+        default=None,
+    )


### PR DESCRIPTION
## 概要
- MCPクライアント登録（設定ファイル）
- Bluesky投稿機能の実装
- human_reviewer後に投稿機能を実行
- 投稿有無はユーザー入力で決定（設定ファイルではなく対話で）

## 実装内容
- StateクラスにBluesky投稿用フィールド追加
- bluesky_posterエージェント新設（human_reviewer→bluesky_poster→END）
- bluesky_posterでユーザー確認・投稿・状態管理
- グラフにbluesky_posterノード追加、条件分岐を整理
- --skip-bluesky-postingオプション追加
- 投稿内容は「{summary}\n{url}」形式（ローカルファイルはURL省略）
- langchain-mcp-adapters.MultiServerMCPClientでMCP連携
- human_reviewerのUI改善（サマリ表示関数抽出、URL表示）

ご確認よろしくお願いします。